### PR TITLE
Fix: enforce number types in fib.ts (fixes #2)

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,10 +1,10 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
-  } else if (n == 0) {
+  } else if (n === 0) {
     return 0;
-  } else if (n == 1) {
+  } else if (n === 1) {
     return 1;
   }
 


### PR DESCRIPTION
Added type annotations to the fibonacci function:
- n is now a number
- function returns a number
