### PR TITLE
Fix: properly type req and res using Express types (Fixes #1)

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,12 +1,11 @@
+import { Request, Response } from "express";
 import fibonacci from "./fib";
 
-export default (req: { params: { num: string } }, res: any) => {
-  const { num } = req.params;  
+export default (req: Request<{ num: string }>, res: Response) => {
+  const { num } = req.params;
+  const fibN = fibonacci(parseInt(num, 10));
 
-  const fibN = fibonacci(parseInt(num));
-
-  let result = `fibonacci(${num}) is ${fibN}`;  
-
+  let result = `fibonacci(${num}) is ${fibN}`;
   if (fibN < 0) {
     result = `fibonacci(${num}) is undefined`;
   }


### PR DESCRIPTION
Fixes #1
Fixed type issues in `fibRoute.ts` by properly typing `req` and `res` with Express types. 
Removed all `any` usage and ensured `res.send()` is safe.
